### PR TITLE
Add cisagov/ansible-role-docker as a dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.2.3
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: markdownlint
         # The LICENSE.md must match the license text exactly for
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.4
+    rev: 1.0.5
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
@@ -45,11 +45,11 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.16.3
+    rev: v1.17.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 2a1dbab
+    rev: 1.6.0
     hooks:
       - id: bandit
         args:
@@ -74,6 +74,6 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.17.0
+    rev: 1.17.1
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.17.1
+    rev: v1.18.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -64,7 +64,7 @@ repos:
       - id: ansible-lint
         # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate_no_variables

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,6 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate_no_variables
-      - id: terraform_docs
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+# Already being linted by pretty-format-json
+*.json
 # Already being linted by mdl
 *.md
 # Already being linted by yamllint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@
 dist: xenial
 language: python
 python: 3.7
+# pre-commit hooks can use Docker, so we should go ahead and enable it
 services: docker
+
+# Cache pip packages and pre-commit plugins to speed up builds
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 
 install:
   - pip install --upgrade -r requirements-test.txt

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,6 @@ galaxy_info:
         - stretch
   galaxy_tags: []
 
-dependencies: []
+dependencies:
+  - src: https://github.com/cisagov/ansible-role-docker
+    name: docker

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,13 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: debian9
-    image: debian:stretch-slim
+  - name: debian9_systemd
+    image: geerlingguy/docker-debian9-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: https://github.com/cisagov/ansible-role-docker
+  name: docker

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,7 @@
-docker # Needed for molecule to work correctly
-flake8
 # Temporarily use the latest molecule from master.  The latest release
 # of molecule does not play well with ansible 2.8.  We will revert
 # this once a new release comes out.
 #
-# Also install flake8, since it appears to be missing from the
-# dependencies for the bleeding edge molecule.
-# molecule
-git+https://github.com/ansible/molecule.git#egg=molecule
+# molecule[docker]
+git+https://github.com/ansible/molecule.git#egg=molecule[docker]
 pre-commit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,7 @@
 docker # Needed for molecule to work correctly
-molecule
+# Temporarily use the latest molecule from master.  The latest release
+# of molecule does not play well with ansible 2.8.  We will revert
+# this once a new release comes out.
+# molecule
+git+https://github.com/ansible/molecule.git#egg=molecule
 pre-commit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,11 @@
 docker # Needed for molecule to work correctly
+flake8
 # Temporarily use the latest molecule from master.  The latest release
 # of molecule does not play well with ansible 2.8.  We will revert
 # this once a new release comes out.
+#
+# Also install flake8, since it appears to be missing from the
+# dependencies for the bleeding edge molecule.
 # molecule
 git+https://github.com/ansible/molecule.git#egg=molecule
 pre-commit


### PR DESCRIPTION
This removes the need to install Docker separately from this role.

Also merge in the upstream changes from cisagov/skeleton-ansible-role.