### PR TITLE
Make AL2023 supported again

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,12 +23,9 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    # Amazon Linux 2023 does not (yet?) offer docker-compose or the
-    # Docker compose plugin:
-    # https://github.com/amazonlinux/amazon-linux-2023/issues/186
-    # - name: Amazon Linux
-    #   versions:
-    #     - "2023"
+    - name: Amazon Linux
+      versions:
+        - "2023"
     - name: Debian
       versions:
         - buster

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,18 +4,15 @@ dependency:
 driver:
   name: docker
 platforms:
-  # Amazon Linux 2023 does not (yet?) offer docker-compose or the
-  # Docker compose plugin:
-  # https://github.com/amazonlinux/amazon-linux-2023/issues/186
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
-  #   name: amazonlinux2023-systemd
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian10-ansible:latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
     path: /var/cyhy/cyhy-mailer
     state: directory
 
+- name: Install tar
+  ansible.builtin.package:
+    name:
+      - tar
+
 - name: Download and untar the cyhy-mailer tarball
   ansible.builtin.unarchive:
     dest: /var/cyhy/cyhy-mailer


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes Amazon Linux 2023 supported again.

## 💭 Motivation and context ##

AL2023 is supported by our Docker Ansible role as of cisagov/ansible-role-docker#70.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.